### PR TITLE
Fix stripEmail()

### DIFF
--- a/app.js
+++ b/app.js
@@ -158,7 +158,6 @@ app.post('/communication/incoming/email', function (req, res) {
     const fromHeader = fields.from[0];
 
     const body = communicate.stripEmail(rawEmailBody);
-    console.log(body);
 
     const attachments = [];
     for (const key in files) {

--- a/app.js
+++ b/app.js
@@ -157,7 +157,8 @@ app.post('/communication/incoming/email', function (req, res) {
     const rawEmailBody = fields.text[0];
     const fromHeader = fields.from[0];
 
-    const body = rawEmailBody;// stripEmail(rawEmailBody, fromHeader);
+    const body = communicate.stripEmail(rawEmailBody);
+    console.log(body);
 
     const attachments = [];
     for (const key in files) {
@@ -252,12 +253,6 @@ function validateRequestParameters(schema, body) {
   }
 
   return { valid, reason };
-}
-
-
-// Removes reply message headers from emails
-function stripEmail(emailString, fromHeader) {
-  return emailString.substr(0, emailString.indexOf(fromHeader));
 }
 
 

--- a/copilot-communications/index.js
+++ b/copilot-communications/index.js
@@ -12,6 +12,7 @@ const fs = require('fs');
 
 exports = module.exports = {};
 
+// Sends an outgoing message
 exports.send = function (type, contact, body, subject) {
   if (type.toLowerCase() == 'email') {
     fs.readFile(__dirname + '/../templates/message.html', 'utf-8', function (err, data) {
@@ -43,6 +44,7 @@ exports.send = function (type, contact, body, subject) {
   }
 };
 
+// Isolates email body in giant email conversation blob
 exports.stripEmail = function (body) {
   return emailParser.EmailReplyParser.parse_reply(body);
 }

--- a/copilot-communications/index.js
+++ b/copilot-communications/index.js
@@ -7,6 +7,7 @@ const dotenv = require('dotenv').config({ path: __dirname + '/../.env' });
 const twilio = require('twilio');
 const sms = new twilio.RestClient(process.env.TWILIO_ACCOUNT_SID, process.env.TWILIO_AUTH_TOKEN);
 const email = require('sendgrid')(process.env.SENDGRID_API_KEY);
+const emailParser = require('emailreplyparser');
 const fs = require('fs');
 
 exports = module.exports = {};
@@ -41,3 +42,7 @@ exports.send = function (type, contact, body, subject) {
     });
   }
 };
+
+exports.stripEmail = function (body) {
+  return emailParser.EmailReplyParser.parse_reply(body);
+}

--- a/copilot-communications/package.json
+++ b/copilot-communications/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "colors": "^1.1.2",
     "dotenv": "^2.0.0",
+    "emailreplyparser": "0.0.5",
     "sendgrid": "^1.9.2",
     "twilio": "^2.9.1"
   }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "body-parser": "^1.15.2",
     "colors": "^1.1.2",
     "dotenv": "^2.0.0",
+    "emailreplyparser": "0.0.5",
     "express": "^4.14.0",
     "firebase": "^3.2.0",
     "hashids": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "body-parser": "^1.15.2",
     "colors": "^1.1.2",
     "dotenv": "^2.0.0",
-    "emailreplyparser": "0.0.5",
     "express": "^4.14.0",
     "firebase": "^3.2.0",
     "hashids": "^1.0.2",


### PR DESCRIPTION
Uses [`emailreplyparser`](https://github.com/mko/emailreplyparser) a JavaScript port of [GitHub's well-known email parser](https://github.com/github/email_reply_parser).

Took it for a test drive, and it seems to perform well.

@ankitr PTAL.
