### PR TITLE
Hide user message data from analytics.

### DIFF
--- a/app.js
+++ b/app.js
@@ -337,7 +337,7 @@ app.post('/communication/incoming/sms', (req, res) => {
 		    .push(message);
 
 		const log = {
-		    length: req.body.Body,
+		    length: (req.body.Body).length,
 		    from: 'user',
 		    delivered: true,
 		    method: 'SMS',


### PR DESCRIPTION
Mistakenly sent the actual message body of incoming user messages rather than the length. Fixed (very luckily before launch).

@rishisankar PTAL.